### PR TITLE
New customize variables

### DIFF
--- a/django-commands.el
+++ b/django-commands.el
@@ -65,11 +65,11 @@ If nil then DJANGO_SETTINGS_MODULE environment variable will be used."
   :type 'function)
 
 (defcustom django-commands-server-clear-on-restart t
-  "clear buffer in django server restart"
+  "If nil, don't erase server output buffer on django server restart"
   :type 'boolean)
 
 (defcustom django-commands-server-skip '("GET /static-")
-  "runserver command ignore patterns"
+  "Regexps for output of the 'runserver' command that should be ignored."
   :type '(repeat string))
 
 

--- a/django-commands.el
+++ b/django-commands.el
@@ -69,7 +69,7 @@ If nil then DJANGO_SETTINGS_MODULE environment variable will be used."
   :type 'boolean)
 
 (defcustom django-commands-server-skip '("GET /static-")
-  "Regexps for output of the 'runserver' command that should be ignored."
+  "Regexps for 'runserver' command output strings that should be ignored."
   :type '(repeat string))
 
 


### PR DESCRIPTION
**django-commands-server-clear-on-restart**
> If nil, don't erase server output buffer on django server restart

**django-commands-server-skip customize variables**
> Regexps for 'runserver' command output strings that should be ignored.